### PR TITLE
ci: validate PR titles against conventional commits

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -1,0 +1,17 @@
+{
+    "LABEL": {
+        "name": "title needs formatting",
+        "color": "EEEEEE"
+    },
+    "CHECKS": {
+        "prefixes": [
+            "[Bot] docs: "
+        ],
+        "regexp": "^(feat|fix|docs|test|ci|chore)!?(\\(.*\\))?!?:.*"
+    },
+    "MESSAGES": {
+        "success": "PR title is valid",
+        "failure": "PR title is invalid",
+        "notice": "PR Title needs to pass regex '^(feat|fix|docs|test|ci|chore)!?(\\(.*\\))?!?:.*"
+    }
+}

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -1,0 +1,24 @@
+name: "Validate PR title"
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+
+jobs:
+  validate:
+    permissions:
+      contents: read
+      pull-requests: read
+    name: Lint title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: thehanimo/pr-title-checker@0cf5902181e78341bb97bb06646396e5bd354b3f # v1.4.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          configuration_path: ".github/pr-title-checker-config.json"


### PR DESCRIPTION
Ensure PR titles are validated against the conventional commit spec, so both normal merges and branches added to the merge queue have parsable messages.