### PR TITLE
docs: add README badges and initial usage

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,3 +1,9 @@
-#+TITLE: nix-ts-mode.el
+#+TITLE: nix-ts-mode
 
 #+PROPERTY: LOGGING nil
+
+[[https://melpa.org/#/nix-ts-mode][file:https://melpa.org/packages/nix-ts-mode-badge.svg]]
+[[https://github.com/remi-gelinas/nix-ts-mode/actions/workflows/test_and_release.yaml][https://img.shields.io/github/actions/workflow/status/remi-gelinas/nix-ts-mode/test_and_release.yaml?event=push&branch=trunk.svg]]
+
+An Emacs major mode for editing Nix expressions, powered by the new
+built-in tree-sitter support in Emacs 29.

--- a/README.org
+++ b/README.org
@@ -3,10 +3,10 @@
 #+PROPERTY: LOGGING nil
 
 [[https://melpa.org/#/nix-ts-mode][file:https://melpa.org/packages/nix-ts-mode-badge.svg]]
-[[https://github.com/remi-gelinas/nix-ts-mode/actions/workflows/test_and_release.yaml][https://img.shields.io/github/actions/workflow/status/remi-gelinas/nix-ts-mode/test_and_release.yaml.svg?event=push&branch=trunk]]
+[[https://github.com/remi-gelinas/nix-ts-mode/actions/workflows/test_and_release.yaml][https://img.shields.io/github/actions/workflow/status/remi-gelinas/nix-ts-mode/test_and_release.yaml.svg?label=Tests&event=push&branch=trunk]]
 
 An Emacs major mode for editing Nix expressions, powered by the new
-built-in tree-sitter support in Emacs 29 and the community-maintained [[https://github.com/nix-community/tree-sitter-nix][~Nix tree-sitter grammar~.]]
+built-in tree-sitter support in Emacs 29 and the community-maintained [[https://github.com/nix-community/tree-sitter-nix][Nix tree-sitter grammar]].
 
 ** Usage
 

--- a/README.org
+++ b/README.org
@@ -6,11 +6,11 @@
 [[https://github.com/remi-gelinas/nix-ts-mode/actions/workflows/test_and_release.yaml][https://img.shields.io/github/actions/workflow/status/remi-gelinas/nix-ts-mode/test_and_release.yaml.svg?event=push&branch=trunk]]
 
 An Emacs major mode for editing Nix expressions, powered by the new
-built-in tree-sitter support in Emacs 29.
+built-in tree-sitter support in Emacs 29 and the community-maintained [[https://github.com/nix-community/tree-sitter-nix][~Nix tree-sitter grammar~.]]
 
-* Usage
+** Usage
 
-`nix-mode` only provides syntax highlighting for now, but will eventually support other tree-sitter powered features such as sexp-movement and smart indenting.
+~nix-mode~ only provides syntax highlighting for now, but will eventually support other tree-sitter powered features such as sexp-movement and smart indenting.
 After installing, enable the mode for Nix files like so:
 
 #+BEGIN_SRC emacs-lisp
@@ -18,7 +18,7 @@ After installing, enable the mode for Nix files like so:
     (add-to-list 'auto-mode-alist '("\\.nix\\'" . nix-ts-mode))
 #+END_SRC
 
-Or with `use-package`:
+Or with ~use-package~:
 
 #+BEGIN_SRC emacs-lisp
     (use-package nix-ts-mode

--- a/README.org
+++ b/README.org
@@ -3,7 +3,24 @@
 #+PROPERTY: LOGGING nil
 
 [[https://melpa.org/#/nix-ts-mode][file:https://melpa.org/packages/nix-ts-mode-badge.svg]]
-[[https://github.com/remi-gelinas/nix-ts-mode/actions/workflows/test_and_release.yaml][https://img.shields.io/github/actions/workflow/status/remi-gelinas/nix-ts-mode/test_and_release.yaml?event=push&branch=trunk.svg]]
+[[https://github.com/remi-gelinas/nix-ts-mode/actions/workflows/test_and_release.yaml][https://img.shields.io/github/actions/workflow/status/remi-gelinas/nix-ts-mode/test_and_release.yaml.svg?event=push&branch=trunk]]
 
 An Emacs major mode for editing Nix expressions, powered by the new
 built-in tree-sitter support in Emacs 29.
+
+* Usage
+
+`nix-mode` only provides syntax highlighting for now, but will eventually support other tree-sitter powered features such as sexp-movement and smart indenting.
+After installing, enable the mode for Nix files like so:
+
+#+BEGIN_SRC emacs-lisp
+    (require 'nix-ts-mode)
+    (add-to-list 'auto-mode-alist '("\\.nix\\'" . nix-ts-mode))
+#+END_SRC
+
+Or with `use-package`:
+
+#+BEGIN_SRC emacs-lisp
+    (use-package nix-ts-mode
+     :mode "\\.nix\\'")
+#+END_SRC


### PR DESCRIPTION
Add the initial MELPA and trunk test workflow badges to the README along with the initial usage explanation.