### PR TITLE
feat: NO-ISSUE Fontify inherit expressions

### DIFF
--- a/nix-ts-mode.el
+++ b/nix-ts-mode.el
@@ -84,6 +84,10 @@
       ("with" @font-lock-keyword-face))
      (assert_expression
       ("assert" @font-lock-keyword-face))
+     (inherit
+      ("inherit" @font-lock-keyword-face))
+     (inherit_from
+      ("inherit" @font-lock-keyword-face))
      ((identifier) @font-lock-keyword-face
       (:match
        ,(rx-to-string

--- a/test/nix-ts-mode-font-lock-test.el
+++ b/test/nix-ts-mode-font-lock-test.el
@@ -77,15 +77,16 @@
   (check-faces "
 let
   pkgs = {
-    test = \"\";
+    test = { key = \"\"; };
   };
 in rec {
-  test = with pkgs; test;
+  test = with pkgs; { inherit (test) key; };
 }"
-	       '(("let" font-lock-keyword-face)
-		 ("in" font-lock-keyword-face)
-		 ("with" font-lock-keyword-face)
-		 ("rec" font-lock-keyword-face))))
+               '(("let" font-lock-keyword-face)
+                 ("in" font-lock-keyword-face)
+                 ("with" font-lock-keyword-face)
+                 ("rec" font-lock-keyword-face)
+                 ("inherit" font-lock-keyword-face))))
 
 (provide 'nix-ts-mode-font-lock-tests)
 ;;; nix-ts-mode-font-lock-tests.el ends here


### PR DESCRIPTION
This assigns the "keyword" font-lock face to the "inherit" keyword in both plain & inherit_from expressions.