### PR TITLE
feat: NO-ISSUE allow usage of `comment-region`

### DIFF
--- a/nix-ts-mode.el
+++ b/nix-ts-mode.el
@@ -199,6 +199,10 @@
     ;; Indentation
     (setq-local treesit-simple-indent-rules nix-ts-mode-indent-rules)
 
+    ;; Comments
+    (setq-local comment-start "#")
+    (setq-local comment-padding " ")
+
     (treesit-major-mode-setup)))
 
 (provide 'nix-ts-mode)


### PR DESCRIPTION
With this, it is now possible to use `M-x comment-region` to get the region commented (or uncommented).