### PR TITLE
fix: NO-ISSUE Add indentation rules for let and attrset

### DIFF
--- a/nix-ts-mode.el
+++ b/nix-ts-mode.el
@@ -177,6 +177,8 @@
      ((parent-is "formals") parent-bol 0)
      ((parent-is "binding_set") parent-bol 0)
      ((parent-is "binding") parent-bol nix-ts-mode-indent-offset)
+     ((parent-is "let_expression") parent-bol nix-ts-mode-indent-offset)
+     ((parent-is "attrset_expression") parent-bol nix-ts-mode-indent-offset)
      ((parent-is "list_expression") parent-bol nix-ts-mode-indent-offset)
      ((parent-is "apply_expression") parent-bol nix-ts-mode-indent-offset)
      ((parent-is "parenthesized_expression") parent-bol nix-ts-mode-indent-offset)))


### PR DESCRIPTION
This PR adds some seemingly missing indentation rules.

Example indentation from

```nix
  inputs = {
    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";| ⇐ cursor here
  };
```

to

```nix
  inputs = {
    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
    | ⇐ cursor here
  };
```

instead of indenting to

```nix
  inputs = {
    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
| ⇐ cursor here
  };
```

Another example indentation from

```nix
  }: let
    supportedSystems = import systems;
    forAllSystems = nixpkgs-unstable.lib.genAttrs supportedSystems;| ⇐ cursor here
  in {
```

to

```nix
  }: let
    supportedSystems = import systems;
    forAllSystems = nixpkgs-unstable.lib.genAttrs supportedSystems;
    | ⇐ cursor here
  in {
```

instead of indenting to

```nix
  }: let
    supportedSystems = import systems;
    forAllSystems = nixpkgs-unstable.lib.genAttrs supportedSystems;
| ⇐ cursor here
  in {
```