### PR TITLE
ci: support Emacs 29.2

### DIFF
--- a/.github/workflows/do-release.yaml
+++ b/.github/workflows/do-release.yaml
@@ -3,7 +3,7 @@ name: Test and release
 env:
   RELEASE_BODY_KEY: release_body
   RELEASE_BODY_PATH: RELEASE_BODY.md
-  EMACS_VERSIONS: '["29.1", "snapshot", "release-snapshot"]'
+  EMACS_VERSIONS: '["29.1", "29.2", "snapshot", "release-snapshot"]'
   EXTRA_NIX_CONFIG: |
     substituters = https://cache.nixos.org/ https://nix-community.cachix.org
     trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     supportedSystems = import systems;
     forAllSystems = nixpkgs-unstable.lib.genAttrs supportedSystems;
   in {
-    supportedEmacsVersions = ["29.1" "snapshot" "release-snapshot"];
+    supportedEmacsVersions = ["29.1" "29.2" "snapshot" "release-snapshot"];
 
     devShells = forAllSystems (system: let
       pre-commit-check = pre-commit-nix.lib.${system}.run {


### PR DESCRIPTION
Emacs 29.2¹ recently hit both nixos-unstable² and release-23.11³
    
¹ https://lists.gnu.org/archive/html/emacs-devel/2024-01/msg00666.html
    
² https://github.com/NixOS/nixpkgs/pull/281789
https://nixpk.gs/pr-tracker.html?pr=281789
    
³ https://github.com/NixOS/nixpkgs/pull/282259
https://nixpk.gs/pr-tracker.html?pr=282259

I hope I've understood correctly the purpose of both the var in the flake and the one in the workflow.