### PR TITLE
ci: support Emacs 29.2 and 29.3 in CI

### DIFF
--- a/nix/emacs-versions.nix
+++ b/nix/emacs-versions.nix
@@ -1,2 +1,2 @@
 # Adjust to add new Emacs versions to CI
-[ "29.1" "snapshot" "release-snapshot" ]
+[ "29.1" "29.2" "29.3" "snapshot" "release-snapshot" ]


### PR DESCRIPTION
Adding CI support for 29.2 from #18, and also adding 29.3. I'll be using this PR as a bit of a test bed for required action passes in the new repo.