### PR TITLE
fix: correct comment syntax entry

### DIFF
--- a/nix-ts-mode.el
+++ b/nix-ts-mode.el
@@ -223,10 +223,10 @@ and for subsequent lines it's the previous line's indentation."
 ;; Syntax map
 (defvar nix-ts-mode--syntax-table
   (let ((table (make-syntax-table)))
-    (modify-syntax-entry ?#  "<"      table)
-    (modify-syntax-entry ?\n ">"      table)
-    (modify-syntax-entry ?/  ". 124b" table)
-    (modify-syntax-entry ?*  ". 23"   table)
+    (modify-syntax-entry ?# "< b" table)
+    (modify-syntax-entry ?\n "> b" table)
+    (modify-syntax-entry ?/ ". 14" table)
+    (modify-syntax-entry ?* ". 23" table)
     table)
   "Syntax table for `nix-ts-mode'.")
 


### PR DESCRIPTION
This was a mistakenly introduced by 3e496e8, adding the "2" flag into the comment syntax entry, caused to Emacs consider the `//` operator as a comment sequence:

```nix
    {
      foo = "foo";
    } // {
      bar = "bar";    # ← comment sequence
    }
```