### PR TITLE
feat: inherit Eglot's nix-mode settings

### DIFF
--- a/nix-ts-mode.el
+++ b/nix-ts-mode.el
@@ -274,7 +274,10 @@ Return nil if there is no name or if NODE is not a defun node."
     (setq-local treesit-defun-type-regexp (rx (or "binding")))
     (setq-local treesit-defun-name-function #'nix-ts-mode--defun-name)
 
-    (treesit-major-mode-setup)))
+    (treesit-major-mode-setup))
+
+  (when (functionp 'derived-mode-add-parents)
+    (derived-mode-add-parents 'nix-ts-mode '(nix-mode))))
 
 (provide 'nix-ts-mode)
 ;;; nix-ts-mode.el ends here


### PR DESCRIPTION
Reason for this change is to inherit the defined configuration for `nix-mode` within `eglot-server-programs` to automate the process of setting up Eglot for this mode.

Current (as of commit date) value for `nix-mode` found within `eglot-server-programs`:
```emacs-lisp
(nix-mode . ,(eglot-alternatives '("nil" "rnix-lsp" "nixd")))
```