### PR TITLE
feat: improve function expression indentation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,15 +3,15 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
-        "owner": "edolstra",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -39,11 +39,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754340878,
-        "narHash": "sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU=",
+        "lastModified": 1770073757,
+        "narHash": "sha256-Vy+G+F+3E/Tl+GMNgiHl9Pah2DgShmIUBJXmbiQPHbI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cab778239e705082fe97bb4990e0d24c50924c04",
+        "rev": "47472570b1e607482890801aeaf29bfb749884f6",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1757034884,
-        "narHash": "sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao=",
+        "lastModified": 1770843696,
+        "narHash": "sha256-LovWTGDwXhkfCOmbgLVA10bvsi/P8eDDpRudgk68HA8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ca77296380960cd497a765102eeb1356eb80fed0",
+        "rev": "2343bbb58f99267223bc2aac4fc9ea301a155a16",
         "type": "github"
       },
       "original": {
@@ -76,11 +76,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1757239681,
-        "narHash": "sha256-E9spYi9lxm2f1zWQLQ7xQt8Xs2nWgr1T4QM7ZjLFphM=",
+        "lastModified": 1770726378,
+        "narHash": "sha256-kck+vIbGOaM/dHea7aTBxdFYpeUl/jHOy5W3eyRvVx8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ab82ab08d6bf74085bd328de2a8722c12d97bd9d",
+        "rev": "5eaaedde414f6eb1aea8b8525c466dc37bba95ae",
         "type": "github"
       },
       "original": {

--- a/nix-ts-mode.el
+++ b/nix-ts-mode.el
@@ -347,6 +347,7 @@ and for subsequent lines it's the previous line's indentation."
 
 (defvar nix-ts-mode-indent-rules
   `((nix
+     ((parent-is "function_expression") parent-bol 0)
      ((parent-is "source_code") column-0 0)
      ((node-is "]") parent-bol 0)
      ((node-is ")") parent-bol 0)

--- a/test/nix-ts-mode-indent-test.el
+++ b/test/nix-ts-mode-indent-test.el
@@ -73,3 +73,9 @@ output is identical to the given expression."
                       (lambda ()
                         (nix-ts-mode)
                         (indent-region (point-min) (point-max)))))
+
+(ert-deftest nix-func-expr ()
+  (ert-test-erts-file (ert-resource-file "indent-func-expr.erts")
+                      (lambda ()
+                        (nix-ts-mode)
+                        (indent-region (point-min) (point-max)))))

--- a/test/resources/indent-func-expr.erts
+++ b/test/resources/indent-func-expr.erts
@@ -1,0 +1,21 @@
+Name: simple-func-expr
+
+=-=
+{
+foo = (
+z:
+x: {
+y = x + z;
+}
+);
+}
+=-=
+{
+  foo = (
+    z:
+    x: {
+      y = x + z;
+    }
+  );
+}
+=-=-=


### PR DESCRIPTION
Improves indentation when trying to add `let`-expression in a function.

Previous:
```nix
{
  config,
  lib,
  pkgs,
  ...
}:

{
  foo = lib.fooBar (
    z:
# <-- When adding `let` here, the indentation is 0
    {
      y = x + z;
    }
  );
}
```

After:
```nix
{
  config,
  lib,
  pkgs,
  ...
}:

{
  foo = lib.fooBar (
    z:
    # <-- Correctly indents the line
    {
      y = x + z;
    }
  );
}
```