### PR TITLE
Indent recursive attrsets like vanilla ones

### DIFF
--- a/nix-ts-mode.el
+++ b/nix-ts-mode.el
@@ -377,7 +377,7 @@ and for subsequent lines it's the previous line's indentation."
      ((match nil "^let_expression" "^body$" nil nil) parent-bol 0)
      
      ((parent-is "^apply_expression$") parent-bol nix-ts-mode-indent-offset)
-     ((parent-is "^attrset_expression$") parent-bol nix-ts-mode-indent-offset)
+     ((parent-is "^\\(?:rec_\\)?attrset_expression$") parent-bol nix-ts-mode-indent-offset)
      ((parent-is "^binding$") parent-bol nix-ts-mode-indent-offset)
      ((parent-is "^formals$") parent-bol nix-ts-mode-indent-offset)
      ((parent-is "^if_expression$") parent-bol nix-ts-mode-indent-offset)

--- a/test/resources/indent-attrset.erts
+++ b/test/resources/indent-attrset.erts
@@ -24,6 +24,33 @@ pi =
 }
 =-=-=
 
+Name: rec-attrset
+
+=-=
+rec {
+hello =
+world;
+
+yes =
+"no";
+
+pi =
+3;
+}
+=-=
+rec {
+  hello =
+    world;
+
+  yes =
+    "no";
+
+  pi =
+    3;
+}
+=-=-=
+
+
 Name: attrset-with-comments
 
 =-=


### PR DESCRIPTION
Currently the case for recursive attrsets is completely missing so their fields get 0 indentation through catchall case.